### PR TITLE
Docs: Fix tiny typo

### DIFF
--- a/docs/BlazorApexCharts.Docs/Components/ChartTypes/BarCharts/Horizontal.razor
+++ b/docs/BlazorApexCharts.Docs/Components/ChartTypes/BarCharts/Horizontal.razor
@@ -21,7 +21,7 @@
                 OrderByDescending="e=>e.Y" 
                 Color = "#e62e00"/>
 </ApexChart>
-</DemoContainer>vvv
+</DemoContainer>
 
 @code {
     private List<Order> Orders { get; set; } = SampleData.GetOrders();


### PR DESCRIPTION
I noticed there were three v's in the docs, I have removed them. 😄 