### PR TITLE
Add UpdateOptionsWithZoomAsync method

### DIFF
--- a/src/Blazor-ApexCharts/ApexChart.razor.cs
+++ b/src/Blazor-ApexCharts/ApexChart.razor.cs
@@ -399,6 +399,12 @@ namespace ApexCharts
             await JSRuntime.InvokeVoidAsync("blazor_apexchart.updateSeries", Options.Chart.Id, jsonSeries, animate);
         }
 
+        public async Task UpdateOptionsWithZoomAsync(bool redrawPaths, bool animate, bool updateSyncedCharts, decimal start, decimal end)
+        {
+            PrepareChart();
+            var json = Serialize(Options);
+            await JSRuntime.InvokeVoidAsync("blazor_apexchart.updateOptionsWithZoom", Options.Chart.Id, json, redrawPaths, animate, updateSyncedCharts, start, end);
+        }
 
         /// <summary>
         /// For no axis charts only provide the seriesIndex value, set dataPointIndex to null

--- a/src/Blazor-ApexCharts/wwwroot/js/blazor-apex-charts.js
+++ b/src/Blazor-ApexCharts/wwwroot/js/blazor-apex-charts.js
@@ -58,6 +58,19 @@
         }
     },
 
+    updateOptionsWithZoom(id, options, redrawPaths, animate, updateSyncedCharts, start, end) {
+        var data = JSON.parse(options, (key, value) =>
+            (key === 'formatter' || key === 'dateFormatter' || key === 'custom') && value.length !== 0 ? eval("(" + value + ")") : value
+        );
+        var chart = this.findChart(id);
+        if (chart !== undefined) {
+            this.LogMethodCall(chart, 'updateOptionsWithZoom ' + start + ', ' + end, options);
+
+            chart.updateOptions(data, redrawPaths, animate, updateSyncedCharts);
+            chart.zoomX(start, end);
+        }
+    },
+
     appendData(id, data) {
         var newData = JSON.parse(data);
         var chart = this.findChart(id);


### PR DESCRIPTION
 - Without this I cannot seem to update live data on a chart without ugly flickering
 - If I call the same sequence from C# (updateOptions, zoomX) then I see the chart update, then the zoom which is very distracting
 - Using this combined call solves the issue