### PR TITLE
allow yAxis Label formatting in .NET 7.0 WASM

### DIFF
--- a/src/Blazor-ApexCharts/wwwroot/js/blazor-apex-charts.js
+++ b/src/Blazor-ApexCharts/wwwroot/js/blazor-apex-charts.js
@@ -2,7 +2,7 @@
 
     getYAxisLabel(value, index, w) {
 
-        if (window.wasmBinaryFile === undefined) {
+        if (window.wasmBinaryFile === undefined && window.WebAssembly === undefined) {
             console.warn("YAxis labels is only supported in Blazor WASM");
             return value;
         }


### PR DESCRIPTION
In .NET 7.0 WASM the property `window.wasmBinaryFile` is no longer available.
This PR adds a second check if `window.WebAssembly` is defined.