### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add a reference to `Blazor-ApexCharts` in your `_Imports.razor`
 ```
 
 ### Chart Options
-Apex Chart options is available in the ApexChartOptions class that can be passed to the chart. More info in Apex documentation [ApexCharts Docs](https://apexcharts.com/docs/options/).
+Apex Chart options are available in the ApexChartOptions class that can be passed to the chart. More info in Apex documentation [ApexCharts Docs](https://apexcharts.com/docs/options/).
 
 
 [![Stargazers repo roster for @apexcharts/Blazor-ApexCharts](https://reporoster.com/stars/dark/apexcharts/Blazor-ApexCharts)](https://github.com/apexcharts/Blazor-ApexCharts/stargazers)


### PR DESCRIPTION
###PULL REQUEST TITLE

Appropriate  Use of Are

###ISSUE

Inappropriate  Use of is

###CHANGES

an article used before "undo" word

###SOLUTION

used "are" instead of "is" because there are mentioned various options so that is plural that's why we use "are" instead of "is".

I hope you look out into this and consider my contribution.