### PR TITLE
fix: label value formatting on non-XY charts

### DIFF
--- a/src/Blazor-ApexCharts/wwwroot/js/blazor-apexcharts.js
+++ b/src/Blazor-ApexCharts/wwwroot/js/blazor-apexcharts.js
@@ -17,10 +17,14 @@ window.blazor_apexchart = {
 
         if (w !== undefined) {
             return w.config.dotNetObject.invokeMethod('JSGetFormattedYAxisValue', value);
-        };
+        }
 
-        if (index !== undefined) {
+        if (index !== undefined && index.w !== undefined && index.w.config !== undefined) {
             return index.w.config.dotNetObject.invokeMethod('JSGetFormattedYAxisValue', value);
+        }
+
+        if (index !== undefined && index.config !== undefined && index.config.dotNetObject !== undefined) {
+            return index.config.dotNetObject.invokeMethod('JSGetFormattedYAxisValue', value);
         }
 
         return value;


### PR DESCRIPTION
This is done to correctly show the tooltip values.


## Bug info
I fixed it by checking the undefined values in the blazor_apexcharts.js wrapper. Not sure if this is the correct way of doing this.

Screenshot of the exception:
<img width="1118" alt="Screenshot 2023-12-23 at 09 45 54" src="https://github.com/apexcharts/Blazor-ApexCharts/assets/10725286/afcfd274-691d-4deb-aab0-6765da793a7b">


## Steps to reproduce:
-  Create a chart with FormatYAxisLabel set. Full example:
   ```
    <ApexChart TItem="TestItem"
                       Title="SeriesType.Pie"
                       FormatYAxisLabel="MyFormatYAxisLabel">

                <ApexPointSeries TItem="TestItem"
                                 Items="Items"
                                 Name="Gross Value"
                                 SeriesType="@type"
                                 XValue="@(e => e.Id)"
                                 YValue="@(e => e.Value)"/>

            </ApexChart>
    
    @code
    {
        public record TestItem(string Id, decimal? Value);
    
        public TestItem[] Items => new[]
        {
            new TestItem("1", 1.0m),
            new TestItem("2", 2.123m),
            new TestItem("3", 3.123m),
            new TestItem("4", null),
            new TestItem("5", 5.123m),
        };
    
        private string MyFormatYAxisLabel(decimal arg)
        {
            return arg.ToString("c"); // should format to euros
        }
    }
   ``` 