### PR TITLE
fix: use JsonElement.TryGetDecimal to format the YAxis value.

### DIFF
--- a/src/Blazor-ApexCharts/Internal/JSHandler.cs
+++ b/src/Blazor-ApexCharts/Internal/JSHandler.cs
@@ -38,12 +38,12 @@ namespace ApexCharts.Internal
         /// Will execute <see cref="ApexChart{TItem}.FormatYAxisLabel"/>
         /// </remarks>
         [JSInvokable]
-        public string JSGetFormattedYAxisValue(object value)
+        public string JSGetFormattedYAxisValue(JsonElement value)
         {
-            if (value == null) { return ""; }
+            if (value.ValueKind == JsonValueKind.Null) { return ""; }
             if (ChartReference.FormatYAxisLabel == null) { return value.ToString(); }
 
-            if (decimal.TryParse(value.ToString(), out var decimalValue))
+            if (value.ValueKind == JsonValueKind.Number && value.TryGetDecimal(out var decimalValue))
             {
                 return ChartReference.FormatYAxisLabel.Invoke(decimalValue);
             }


### PR DESCRIPTION
This is done to avoid decimal parsing issues when applications set a non-US culture that use a different decimal separator (such as it-IT).

## Bug info
I reproduced this bug on Blazor WASM, this has been present for a long time (Blazor-ApexCharts v1.x). 
If the application sets the current culture to a culture that does not use the dot . as the decimal separator, then the decimal passed to the FormatYAxisLabel callback has all the decimals removed. Ex. the value 1.23 becomes 123.

I fixed it by not relying on decimal.Parse but on the JsonElement.TryGetDecimal method, that works correctly regardless of the current culture.

## Steps to reproduce:
- Set the current culture to `it-IT`.
  ```cs
  CultureInfo.DefaultThreadCurrentCulture = CultureInfo.GetCultureInfo("it-IT");
  CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.GetCultureInfo("it-IT");
   ```
   
 - Create a chart with FormatYAxisLabel set. Full example:
   ```
    <ApexChart TItem="TestItem"
               Title="@($"Current Culture: {CultureInfo.CurrentCulture.Name}")"
               FormatYAxisLabel="MyFormatYAxisLabel">
    
        <ApexPointSeries TItem="TestItem"
                         Items="Items"
                         Name="Gross Value"
                         SeriesType="@SeriesType.Bar"
                         XValue="@(e => e.Id)"
                         YValue="@(e => e.Value)"/>
    
    </ApexChart>
    
    @code
    {
        public record TestItem(string Id, decimal? Value);
    
        public TestItem[] Items => new[]
        {
            new TestItem("1", 1.0m),
            new TestItem("2", 2.123m),
            new TestItem("3", 3.123m),
            new TestItem("4", null),
            new TestItem("5", 5.123m),
        };
    
        private string MyFormatYAxisLabel(decimal arg)
        {
            return arg.ToString("c"); // should format to euros
        }
    }
   ``` 