### PR TITLE
Add AppendDataBySeriesNameAsync() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,3 @@ Credits to [@thirstyape](https://github.com/thirstyape) for making production re
 
 
 [![Stargazers repo roster for @apexcharts/Blazor-ApexCharts](https://reporoster.com/stars/dark/apexcharts/Blazor-ApexCharts)](https://github.com/apexcharts/Blazor-ApexCharts/stargazers)
-

--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ Credits to [@thirstyape](https://github.com/thirstyape) for making production re
 
 
 [![Stargazers repo roster for @apexcharts/Blazor-ApexCharts](https://reporoster.com/stars/dark/apexcharts/Blazor-ApexCharts)](https://github.com/apexcharts/Blazor-ApexCharts/stargazers)
+

--- a/src/Blazor-ApexCharts/ApexChart.razor.cs
+++ b/src/Blazor-ApexCharts/ApexChart.razor.cs
@@ -712,6 +712,45 @@ namespace ApexCharts
         }
 
         /// <summary>
+        /// This method allows you to append new data to the series arrays, referencing each series by name
+        /// </summary>
+        /// <param name="items">The dictinoary with the data array to append the existing series datasets, using the key as the series name.</param>
+        /// <remarks>
+        /// Links:
+        /// 
+        /// <see href="https://apexcharts.github.io/Blazor-ApexCharts/methods/append-data">Blazor Example</see>,
+        /// <see href="https://apexcharts.com/docs/methods/#appendData">JavaScript Documentation</see>
+        /// </remarks>
+        public virtual async Task AppendDataBySeriesNameAsync(Dictionary<string, IEnumerable<TItem>> items)
+        {
+            if (IsNoAxisChart)
+            {
+                throw new Exception($"{typeof(ApexChart<TItem>)}.{nameof(AppendDataBySeriesNameAsync)}: Operation not valid for no axis charts.");
+            }
+
+            var seriesList = new List<AppendData<TItem>>();
+
+            foreach (var apxSeries in Options.Series)
+            {
+                if(items.ContainsKey(apxSeries.Name))
+                {
+                    var data = apxSeries.ApexSeries.GenerateDataPoints(items[apxSeries.Name]);
+                    var updatedData = apxSeries.Data.ToList();
+                    updatedData.AddRange(data);
+                    apxSeries.Data = updatedData;
+
+                    seriesList.Add(new AppendData<TItem>
+                    {
+                        Data = data
+                    }); ;
+                }
+            }
+
+            var json = Serialize(seriesList);
+            await InvokeVoidJsAsync("blazor_apexchart.appendData", Options.Chart.Id, json);
+        }
+
+        /// <summary>
         /// Manually zoom into the chart with the start and end X values.
         /// </summary>
         /// <param name="zoomOptions">Undefined</param>


### PR DESCRIPTION
I ran into some problems displaying a realtime chart with multiple series. I've opened an issue (#403), but realized that using UpdateSeriesAsync() is not optimal and AppendDataAsync() is better suited since it doesn't reset the series options on call.

My problem was it works fine with a single series, but there's no way to append to a specific series. As far as I can see the data passed to AppendDataAsync() is added to all existing series, which makes little sense in my opinion (correct me if I misunderstood something). I've added a method that allows to add data to specific series, referencing them by name. This maybe is not optimal, since names are not necessarily unique, but it works for my case. Ultimately it would be better to add a unique identifier to the Series object, so that series could be better adressed.