### PR TITLE
Solution proposed to issue #408

### DIFF
--- a/docs/BlazorApexCharts.Docs/Components/Features/Annotations/AnnotationsSamples.razor
+++ b/docs/BlazorApexCharts.Docs/Components/Features/Annotations/AnnotationsSamples.razor
@@ -2,8 +2,6 @@
 
 <DocExamples Title="Annotations" >
 
-
-
     <CodeSnippet Title=Basic ClassName=@typeof(Basic).ToString()>
         <Snippet>
              <Basic/>
@@ -22,6 +20,11 @@
         </Snippet>
     </CodeSnippet>
 
+    <CodeSnippet Title="Multiline" ClassName=@typeof(Multiline).ToString()>
+        <Snippet>
+            <Multiline />
+        </Snippet>
+    </CodeSnippet>
 @*     <CodeSnippet Title=Horizontal ClassName=@typeof(Horizontal).ToString()>
         <Snippet>
             <Horizontal />

--- a/docs/BlazorApexCharts.Docs/Components/Features/Annotations/Multiline.razor
+++ b/docs/BlazorApexCharts.Docs/Components/Features/Annotations/Multiline.razor
@@ -1,0 +1,61 @@
+﻿<DemoContainer>
+    <ApexChart TItem="Order"
+               Title="Multiline Samples"
+               Options=options Debug=true>
+
+        <ApexPointSeries TItem="Order"
+                         Items="orders"
+                         Name="% Gross"
+                         SeriesType="SeriesType.Bar"
+                         XValue="@(e => e.DiscountPercentage)"
+                         YValue="@(e => e.GrossValue)"
+                         OrderByDescending="e=>e.X" />
+
+        <ApexPointSeries TItem="Order"
+                         Items="orders"
+                         SeriesType="SeriesType.Bar"
+                         Name="% Net"
+                         XValue="@(e => e.DiscountPercentage)"
+                         YValue="@(e => e.NetValue)"
+                         OrderByDescending="e=>e.X" />
+    </ApexChart>
+</DemoContainer>
+
+@code {
+    private List<Order> orders { get; set; } = SampleData.GetOrders();
+    private ApexChartOptions<Order> options = new ApexChartOptions<Order>();
+
+    protected override void OnInitialized()
+    {
+
+        options.Annotations = new Annotations
+            {
+                Xaxis = new List<AnnotationsXAxis> { new AnnotationsXAxis
+                    {
+                        Label = new Label {
+                            Text = new List<string>{ "X Axis 1", "X Axis 2" },
+                            // to avoid the annotation text to overlap the line
+                            OffsetX = -10,
+                        },
+                        X = 40,
+                        StrokeDashArray = 2,
+                        BorderColor = "red"
+                    }
+                },
+                Yaxis = new List<AnnotationsYAxis> { new AnnotationsYAxis
+                    {
+                        Label = new Label
+                        {
+                            Text = new List<string>{ "Y Axis 1", "Y Axis 2" },
+                            // to avoid the annotation text to overlap the line
+                            OffsetY = -20,
+                        },
+                        Y = 70000,
+                        BorderColor = "blue",
+                        StrokeDashArray = 0
+                    }
+                }
+
+            };
+    }
+}

--- a/src/Blazor-ApexCharts/Models/ApexChartOptions.cs
+++ b/src/Blazor-ApexCharts/Models/ApexChartOptions.cs
@@ -489,7 +489,7 @@ namespace ApexCharts
         /// <summary>
         /// Text for tha annotation label (single string or List<string> to put a multine label
         /// </summary>
-        public object Text { get; set; }
+        public LabelText Text { get; set; }
 
         /// <summary>
         /// The alignment of text relative to label's drawing position
@@ -529,6 +529,55 @@ namespace ApexCharts
                     return;
             }
         }
+    }
+
+    /// <remarks>
+    /// Accepts either a single value or collection of values. 
+    /// By providing a collection in the case of chart annotations, the supplied strings will be printed as separate lines, thus allowing for multiline annotation handling.<br /><br />
+    /// 
+    /// Example:<br /><br />
+    /// 
+    /// <code>
+    /// // Single text
+    /// options.Annotations[0].Xaxis.Label.Text = "TextAnnotations";
+    /// 
+    /// // Multiple texts
+    /// Annotations = new Annotations {
+    ///             Xaxis = new List<AnnotationsXAxis> { 
+    ///                 new AnnotationsXAxis {
+    ///                     Label = new Label {
+    ///                         Text = new LabelText("Annotation Text")
+    ///                     }
+    ///                 }
+    ///             }
+    /// </code>
+    /// </remarks>
+    public class LabelText : ValueOrList<string>
+    {
+        /// <summary>
+        /// Converts a label text collection into a list of strings
+        /// </summary>
+        public static implicit operator List<string>(LabelText source) => source.values;
+
+        /// <summary>
+        /// Converts a list of strings into an label text collection
+        /// </summary>
+        public static implicit operator LabelText(List<string> source) => new(source);
+
+        /// <summary>
+        /// Converts a string into an label text collection
+        /// </summary>
+        public static implicit operator LabelText(string source) => new(source);
+
+        /// <summary>
+        /// Creates a new collection of label texts with the provided values
+        /// </summary>
+        public LabelText(params string[] values) : base(values) { }
+
+        /// <summary>
+        /// Creates a new collection of label texts with the provided values
+        /// </summary>
+        public LabelText(IEnumerable<string> values) : base(values) { }
     }
 
 

--- a/src/Blazor-ApexCharts/Models/ApexChartOptions.cs
+++ b/src/Blazor-ApexCharts/Models/ApexChartOptions.cs
@@ -487,9 +487,9 @@ namespace ApexCharts
         public Style Style { get; set; }
 
         /// <summary>
-        /// Text for tha annotation label
+        /// Text for tha annotation label (single string or List<string> to put a multine label
         /// </summary>
-        public string Text { get; set; }
+        public object Text { get; set; }
 
         /// <summary>
         /// The alignment of text relative to label's drawing position


### PR DESCRIPTION
As said in the issue #408, this solution to change the type of Label.Text property from **string** in **object** could help to handle multiline annotations. I added also the sample to show the results.

**_!!! ATTENTION:_** please, if you notice that the vertical annotations is not aligned on the same side: DON'T worry: it's not caused by the Blazor wrapper, or this new feature, but it also happens in the current version as shown in my PEN [here](https://codepen.io/peterboccia/pen/bGZzorr) and as shown in the photo:
![image](https://github.com/apexcharts/Blazor-ApexCharts/assets/7672129/76a09c9e-8bc9-4d25-87b9-8952be75de81)

I'll open an issue on their github and see if they could fix it.

Thank you for your attention and I hope you can find my PR useful.