### PR TITLE
feat: add X Axis Label Formatter

### DIFF
--- a/docs/BlazorApexCharts.Docs/Components/Features/Formatters/FormatterSamples.razor
+++ b/docs/BlazorApexCharts.Docs/Components/Features/Formatters/FormatterSamples.razor
@@ -48,6 +48,26 @@
         </Snippet>
     </CodeSnippet>
 
+    <CodeSnippet Title="Use DotNet for X Axis" ClassName=@typeof(UseDotNetXAxis).ToString()>
+        <Description>
+            <Alert BackgroundColor=TablerColor.Danger>
+
+                <div class="d-flex">
+                    <div class="me-2">
+                        <Icon TextColor=TablerColor.Danger IconType=@Icons.Alert_triangle Size=40 />
+                    </div>
+                    <div>
+                        <h4 class="alert-title">Only supported in Blazor WebAssembly!</h4>
+                        <div class="text-muted">Currently this is only supported in web assembly</div>
+                    </div>
+                </div>
+            </Alert>
+        </Description>
+        <Snippet>
+            <UseDotNetXAxis />
+        </Snippet>
+    </CodeSnippet>
+
 
 
 </DocExamples>

--- a/docs/BlazorApexCharts.Docs/Components/Features/Formatters/UseDotNetXAxis.razor
+++ b/docs/BlazorApexCharts.Docs/Components/Features/Formatters/UseDotNetXAxis.razor
@@ -1,0 +1,50 @@
+﻿<DemoContainer>
+    <ApexChart TItem="Order"
+               Title="Order Net Value"
+               FormatXAxisLabel="GetXAxisLabel"
+               Options="options">
+
+        <ApexPointSeries TItem="Order"
+                         Items="Orders"
+                         Name="Gross Value"
+                         XValue="@(e => e.Country)"
+                         SeriesType="SeriesType.Bar"
+                         YAggregate="@(e => e.Sum(e => e.GrossValue))"
+                         OrderByDescending="e=>e.Y"
+                         Color="#003399"/>
+
+        <ApexPointSeries TItem="Order"
+                         Items="Orders"
+                         Name="Net Value"
+                         SeriesType="SeriesType.Bar"
+                         XValue="@(e => e.Country)"
+                         YAggregate="@(e => e.Sum(e => e.NetValue))"
+                         OrderByDescending="e=>e.Y"
+                         Color = "#e62e00"/>
+    </ApexChart>
+</DemoContainer>
+
+@code {
+    private List<Order> Orders { get; set; } = SampleData.GetOrders();
+    private ApexChartOptions<Order> options;
+
+    protected override void OnInitialized()
+    {
+        options = new ApexChartOptions<Order>
+        {
+            PlotOptions = new PlotOptions
+            {
+                Bar = new PlotOptionsBar
+                {
+                    Horizontal = true
+                }
+            }
+        };
+    }
+    
+    private string GetXAxisLabel(decimal value)
+    {
+        return "$" + value.ToString("N0");
+    }
+
+}

--- a/src/Blazor-ApexCharts/ApexChart.razor.cs
+++ b/src/Blazor-ApexCharts/ApexChart.razor.cs
@@ -328,6 +328,16 @@ namespace ApexCharts
         [Parameter] public Func<decimal, string> FormatYAxisLabel { get; set; }
 
         /// <summary>
+        /// A custom function to execute for generating X-axis labels. Only supported in Blazor WebAssembly!
+        /// </summary>
+        /// <remarks>
+        /// Links:
+        /// 
+        /// <see href="https://apexcharts.github.io/Blazor-ApexCharts/features/formatters">Blazor Example</see>
+        /// </remarks>
+        [Parameter] public Func<decimal, string> FormatXAxisLabel { get; set; }
+
+        /// <summary>
         /// Enables merging multiple data points into a single item in the chart
         /// </summary>
         /// <remarks>
@@ -1171,6 +1181,19 @@ namespace ApexCharts
 
                 yAxis.Labels.Formatter = @"function (value, index, w) {
                                           return window.blazor_apexchart.getYAxisLabel(value, index, w);
+                                         }";
+            }
+
+            if (FormatXAxisLabel != null)
+            {
+                if (Options.Xaxis == null) { Options.Xaxis = new XAxis(); }
+
+                var xAxis = Options.Xaxis;
+
+                xAxis.Labels ??= new XAxisLabels();
+
+                xAxis.Labels.Formatter = @"function (value, index, w) {
+                                          return window.blazor_apexchart.getXAxisLabel(value, index, w);
                                          }";
             }
         }

--- a/src/Blazor-ApexCharts/Internal/JSHandler.cs
+++ b/src/Blazor-ApexCharts/Internal/JSHandler.cs
@@ -53,6 +53,27 @@ namespace ApexCharts.Internal
         }
 
         /// <summary>
+        /// Callback from JavaScript to get a formatted X-axis value
+        /// </summary>
+        /// <param name="value">Details from JavaScript</param>
+        /// <remarks>
+        /// Will execute <see cref="ApexChart{TItem}.FormatXAxisLabel"/>
+        /// </remarks>
+        [JSInvokable]
+        public string JSGetFormattedXAxisValue(JsonElement value)
+        {
+            if (value.ValueKind == JsonValueKind.Null) { return ""; }
+            if (ChartReference.FormatXAxisLabel == null) { return value.ToString(); }
+
+            if (value.ValueKind == JsonValueKind.Number && value.TryGetDecimal(out var decimalValue))
+            {
+                return ChartReference.FormatXAxisLabel.Invoke(decimalValue);
+            }
+
+            return value.ToString();
+        }
+
+        /// <summary>
         /// Callback from JavaScript on zoom
         /// </summary>
         /// <param name="jSZoomed">Details from JavaScript</param>

--- a/src/Blazor-ApexCharts/wwwroot/js/blazor-apexcharts.js
+++ b/src/Blazor-ApexCharts/wwwroot/js/blazor-apexcharts.js
@@ -8,6 +8,32 @@ export function get_apexcharts() {
 
 window.blazor_apexchart = {
 
+    getXAxisLabel(value, index, w) {
+
+        if (window.wasmBinaryFile === undefined && window.WebAssembly === undefined) {
+            console.warn("XAxis labels is only supported in Blazor WASM");
+            return value;
+        }
+
+        if (w !== undefined && w.w !== undefined) {
+            return w.w.config.dotNetObject.invokeMethod('JSGetFormattedXAxisValue', value);
+        }
+
+        if (w !== undefined && w.config !== undefined) {
+            return w.config.dotNetObject.invokeMethod('JSGetFormattedXAxisValue', value);
+        }
+
+        if (index !== undefined && index.w !== undefined && index.w.config !== undefined) {
+            return index.w.config.dotNetObject.invokeMethod('JSGetFormattedXAxisValue', value);
+        }
+
+        if (index !== undefined && index.config !== undefined && index.config.dotNetObject !== undefined) {
+            return index.config.dotNetObject.invokeMethod('JSGetFormattedXAxisValue', value);
+        }
+
+        return value;
+    },
+
     getYAxisLabel(value, index, w) {
 
         if (window.wasmBinaryFile === undefined && window.WebAssembly === undefined) {
@@ -419,7 +445,7 @@ window.blazor_apexchart = {
 
         //Always destroy chart if it exists
         this.destroyChart(options.chart.id);
-        
+
         var chart = new ApexCharts(container, options);
         chart.render();
 


### PR DESCRIPTION
## Summary

This PR adds the possibility to format X Axis labels using .NET (as users can already done with Y Axis Labels using the FormatYAxisLabel parameter of the ApexChart component).

This is particularly useful in those cases when using horizontal bar charts. 

```
<ApexChart TItem="Order"
               Title="Order Net Value"
               FormatXAxisLabel="GetXAxisLabel"
               Options="options">
@* ... *@
</ApexChart>

@code
{

// ...

    private string GetXAxisLabel(decimal value)
    {
        return "$" + value.ToString("N0");
    }

// ...
}
```

## Screenshots
![image](https://github.com/apexcharts/Blazor-ApexCharts/assets/24456379/d7d4abc2-8178-4bed-972d-887c0daf4eaa)

## Things to consider

This does not address a problem on the values shown in the tooltip shown on mouse hover; as far as I know, it looks like the problem is not related to the Blazor wrapper implementation but to the underlying Apex Charts Js library. An issues already exists for this: https://github.com/apexcharts/apexcharts.js/issues/4472
