### PR TITLE
StrokeColor added to mutator and Mutator example in LineChart

### DIFF
--- a/docs/BlazorApexCharts.Docs/Components/ChartTypes/LineCharts/LineCharts.razor
+++ b/docs/BlazorApexCharts.Docs/Components/ChartTypes/LineCharts/LineCharts.razor
@@ -50,4 +50,10 @@
         </Snippet>
     </CodeSnippet>
 
+    <CodeSnippet Title="Point Mutator" ClassName=@typeof(PointMutate).ToString()>
+        <Snippet>
+            <PointMutate />
+        </Snippet>
+    </CodeSnippet>
+
 </DocExamples>

--- a/docs/BlazorApexCharts.Docs/Components/ChartTypes/LineCharts/PointMutate.razor
+++ b/docs/BlazorApexCharts.Docs/Components/ChartTypes/LineCharts/PointMutate.razor
@@ -1,0 +1,43 @@
+﻿<DemoContainer>
+    <ApexChart TItem="Order"
+               Title="Order Net Value" Options="@options">
+
+        <ApexPointSeries TItem="Order"
+                         Items="Orders"
+                         Name="Gross Value"
+                         
+                         SeriesType="SeriesType.Line"
+                         XValue="@(e => e.OrderDate)"
+                         YValue="@(e => e.GrossValue)"
+                         DataPointMutator="MutateDataPoint"
+                         OrderByDescending="e=>e.Y" />
+    </ApexChart>
+</DemoContainer>
+
+@code {
+    private List<Order> Orders { get; set; } = SampleData.GetOrders().Where(n => n.Country == "Sweden").ToList();
+
+    private ApexChartOptions<Order> options = new ApexCharts.ApexChartOptions<Order>()
+    {
+        Markers = new Markers
+        {
+            Size = 6,
+            FillOpacity = 1,
+            StrokeWidth = 2,
+            StrokeColors = new List<string> { "#FFFFFF" },
+            Colors = new List<string> { "#0000FF" },
+            StrokeOpacity = 1d
+        }
+    };
+
+    private void MutateDataPoint(DataPoint<Order> point)
+    {
+        var max = Orders.Max(e => e.GrossValue);
+
+        if (point.Items.Any(n => n.GrossValue == max))
+        {
+            point.FillColor = "#FF0000";
+            point.StrokeColor = "#00FFFF";
+        }
+    }
+}

--- a/src/Blazor-ApexCharts/Models/DataPoints/DataPoint.cs
+++ b/src/Blazor-ApexCharts/Models/DataPoints/DataPoint.cs
@@ -12,8 +12,13 @@ namespace ApexCharts
         /// <inheritdoc cref="IDataPoint{TItem}.FillColor"/>
         public string FillColor { get; set; }
 
-        /// <inheritdoc cref="IDataPoint{TItem}.X"/>
-        public object X { get; set; }
+		/// <summary>
+		/// Controls the color of the border around the data point
+		/// </summary>
+		public string StrokeColor { get; set; }
+
+		/// <inheritdoc cref="IDataPoint{TItem}.X"/>
+		public object X { get; set; }
 
         /// <summary>
         /// A collection of goal markers to display with the data point


### PR DESCRIPTION
Example added for DataPointMutator inside ApexPointSeries and added the ability to change the StrokeColor (not just the FillColor).

Added a small demo if this to the documentation.

<img width="557" height="365" alt="grafik" src="https://github.com/user-attachments/assets/375937d3-f902-477c-be44-3f110ec7f884" />

```xml
<ApexPointSeries TItem="Order"
                         Items="Orders"
                         Name="Gross Value"
                         
                         SeriesType="SeriesType.Line"
                         XValue="@(e => e.OrderDate)"
                         YValue="@(e => e.GrossValue)"
                         DataPointMutator="MutateDataPoint"
                         OrderByDescending="e=>e.Y" />
```

```c#
private void MutateDataPoint(DataPoint<Order> point)
    {
        var max = Orders.Max(e => e.GrossValue);

        if (point.Items.Any(n => n.GrossValue == max))
        {
            point.FillColor = "#FF0000";
            point.StrokeColor= "#00FFFF";
        }
    }
```