### PR TITLE
Add support for .NET 10.0

### DIFF
--- a/.github/workflows/dotnetcore-maui.yml
+++ b/.github/workflows/dotnetcore-maui.yml
@@ -19,7 +19,9 @@ jobs:
     - name: Setup dotnet ${{ matrix.dotnet-version }}.0.x
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: ${{ matrix.dotnet-version }}.0.x
+        dotnet-version: |
+          10.0.x
+          ${{ matrix.dotnet-version }}.0.x
     - name: Install dependencies
       run: |
         dotnet workload install maui

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -19,7 +19,9 @@ jobs:
     - name: Setup dotnet ${{ matrix.dotnet-version }}.0.x
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: ${{ matrix.dotnet-version }}.0.x
+        dotnet-version: |
+          10.0.x
+          ${{ matrix.dotnet-version }}.0.x
     - name: Install dependencies
       run: dotnet restore
       working-directory: ./src/Blazor-ApexCharts

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        dotnet-version: [8, 9]
+        dotnet-version: [8, 9, 10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,10 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          8.0.x
+          9.0.x
+          10.0.x
 
     - name: Dotnet Pack 
       working-directory: ./src/Blazor-ApexCharts

--- a/Blazor-ApexCharts.slnx
+++ b/Blazor-ApexCharts.slnx
@@ -1,0 +1,9 @@
+<Solution>
+  <Folder Name="/Docs/">
+    <Project Path="docs/BlazorApexCharts.Docs.Server/BlazorApexCharts.Docs.Server.csproj" />
+    <Project Path="docs/BlazorApexCharts.Docs.Wasm/BlazorApexCharts.Docs.Wasm.csproj" />
+    <Project Path="docs/BlazorApexCharts.Docs/BlazorApexCharts.Docs.csproj" />
+  </Folder>
+  <Project Path="src/Blazor-ApexCharts-MAUI/Blazor-ApexCharts-MAUI.csproj" />
+  <Project Path="src/Blazor-ApexCharts/Blazor-ApexCharts.csproj" />
+</Solution>

--- a/src/Blazor-ApexCharts/Blazor-ApexCharts.csproj
+++ b/src/Blazor-ApexCharts/Blazor-ApexCharts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 
 		<Authors>Joakim Dangården</Authors>
 		<Company />
@@ -30,6 +30,11 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.2" />
 	</ItemGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<None Include="..\..\LICENSE">


### PR DESCRIPTION
Simple update, add targeting for .NET 10.0 to the main project. 

I did not change MAUI or the docs as their current support end dates are May 12, 2026 and November 10, 2026 respectively. 

Also added the newer .slnx file as it will likely be phased in over the next couple years.