### PR TITLE
Add per-series colorStops support for fill gradients

### DIFF
--- a/src/Blazor-ApexCharts/Internal/ChartSerializer.cs
+++ b/src/Blazor-ApexCharts/Internal/ChartSerializer.cs
@@ -34,6 +34,7 @@ namespace ApexCharts.Internal
             serializerOptions.Converters.Add(new ValueOrListConverter<Curve>());
             serializerOptions.Converters.Add(new ValueOrListConverter<FillPatternStyle>());
             serializerOptions.Converters.Add(new ValueOrListConverter<FillType>());
+            serializerOptions.Converters.Add(new ColorStopsConverter());
 
             return serializerOptions;
         }

--- a/src/Blazor-ApexCharts/Internal/Converters/ColorStopsConverter.cs
+++ b/src/Blazor-ApexCharts/Internal/Converters/ColorStopsConverter.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ApexCharts.Internal
+{
+    /// <summary>
+    /// Serializes <see cref="ColorStopsCollection"/> as either a flat array (shared)
+    /// or a nested array (per-series) depending on how it was constructed.
+    /// </summary>
+    internal class ColorStopsConverter : JsonConverter<ColorStopsCollection>
+    {
+        /// <inheritdoc/>
+        /// <exception cref="NotImplementedException"/>
+        public override ColorStopsCollection Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, ColorStopsCollection value, JsonSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            if (value.IsPerSeries)
+            {
+                // Nested array: [[{offset, color, opacity}, ...], [...]]
+                JsonSerializer.Serialize(writer, value.PerSeriesStops, options);
+            }
+            else
+            {
+                // Flat array: [{offset, color, opacity}, ...]
+                JsonSerializer.Serialize(writer, value.PerSeriesStops[0], options);
+            }
+        }
+    }
+}

--- a/src/Blazor-ApexCharts/Models/ApexChartOptions.cs
+++ b/src/Blazor-ApexCharts/Models/ApexChartOptions.cs
@@ -2012,7 +2012,8 @@ namespace ApexCharts
         public GradientType Type { get; set; }
 
         /// <inheritdoc cref="ApexCharts.FillGradientStops"/>
-        public List<FillGradientStops> ColorStops { get; set; }
+        /// <inheritdoc cref="ApexCharts.ColorStopsCollection"/>
+        public ColorStopsCollection ColorStops { get; set; }
     }
 
     /// <summary>

--- a/src/Blazor-ApexCharts/Models/MultiType/ColorStopsCollection.cs
+++ b/src/Blazor-ApexCharts/Models/MultiType/ColorStopsCollection.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+
+namespace ApexCharts
+{
+    /// <summary>
+    /// Represents gradient color stops that can be shared across all series or specified per-series.
+    /// <br /><br />
+    /// The ApexCharts JS API accepts <c>colorStops</c> as either a flat array (shared by all series)
+    /// or a nested array where each inner array corresponds to a series index.
+    /// <br /><br />
+    /// <code>
+    /// // Shared stops (all series use the same gradient)
+    /// ColorStops = new List&lt;FillGradientStops&gt;
+    /// {
+    ///     new() { Offset = 0, Color = "#FF0000", Opacity = 1 },
+    ///     new() { Offset = 100, Color = "#00FF00", Opacity = 1 }
+    /// };
+    ///
+    /// // Per-series stops (each series gets its own gradient)
+    /// ColorStops = new List&lt;List&lt;FillGradientStops&gt;&gt;
+    /// {
+    ///     new() { new() { Offset = 0, Color = "#FF0000", Opacity = 1 } }, // series 0
+    ///     new() { new() { Offset = 0, Color = "#0000FF", Opacity = 1 } }  // series 1
+    /// };
+    /// </code>
+    /// </summary>
+    public class ColorStopsCollection
+    {
+        internal List<List<FillGradientStops>> PerSeriesStops { get; }
+        internal bool IsPerSeries { get; }
+
+        /// <summary>
+        /// Creates a shared color stops collection (all series use the same stops).
+        /// </summary>
+        public ColorStopsCollection(List<FillGradientStops> stops)
+        {
+            PerSeriesStops = new List<List<FillGradientStops>> { stops };
+            IsPerSeries = false;
+        }
+
+        /// <summary>
+        /// Creates a per-series color stops collection (each inner list corresponds to a series index).
+        /// </summary>
+        public ColorStopsCollection(List<List<FillGradientStops>> perSeriesStops)
+        {
+            PerSeriesStops = perSeriesStops;
+            IsPerSeries = true;
+        }
+
+        /// <summary>
+        /// Implicitly converts a flat list of stops into a shared color stops collection.
+        /// </summary>
+        public static implicit operator ColorStopsCollection(List<FillGradientStops> stops) => new(stops);
+
+        /// <summary>
+        /// Implicitly converts a nested list of stops into a per-series color stops collection.
+        /// </summary>
+        public static implicit operator ColorStopsCollection(List<List<FillGradientStops>> perSeriesStops) => new(perSeriesStops);
+    }
+}


### PR DESCRIPTION
colorStops in the JS API supports both flat and nested arrays, but the wrapper only had the flat variant. This adds a ColorStopsCollection type with implicit operators, so both formats just work. It should be backward compatible.
