### PR TITLE
Fix JSDisconnectedException during chart disposal

### DIFF
--- a/src/Blazor-ApexCharts/ApexChart.razor.cs
+++ b/src/Blazor-ApexCharts/ApexChart.razor.cs
@@ -1342,20 +1342,17 @@ namespace ApexCharts
         /// <inheritdoc/>
         public virtual void Dispose()
         {
-            _ = DisposeAsync();
+            DisposeCore();
+            GC.SuppressFinalize(this);
         }
 
         /// <inheritdoc/>
         public virtual async ValueTask DisposeAsync()
         {
-            if (Interlocked.Exchange(ref isDisposed, 1) != 0)
+            if (!DisposeCore())
             {
                 return;
             }
-
-            GC.SuppressFinalize(this);
-
-            chartService?.UnRegisterChart(this);
 
             try
             {
@@ -1372,8 +1369,20 @@ namespace ApexCharts
             { }
             finally
             {
-                JSHandler?.Dispose();
+                GC.SuppressFinalize(this);
             }
+        }
+
+        private bool DisposeCore()
+        {
+            if (Interlocked.Exchange(ref isDisposed, 1) != 0)
+            {
+                return false;
+            }
+
+            chartService?.UnRegisterChart(this);
+            JSHandler?.Dispose();
+            return true;
         }
 
         internal void UpdateTooltipData(HoverData<TItem> tooltipData)

--- a/src/Blazor-ApexCharts/ApexChart.razor.cs
+++ b/src/Blazor-ApexCharts/ApexChart.razor.cs
@@ -1342,14 +1342,32 @@ namespace ApexCharts
         /// <inheritdoc/>
         public virtual void Dispose()
         {
-            DisposeCore();
-            GC.SuppressFinalize(this);
+            if (!TryBeginDispose())
+            {
+                return;
+            }
+
+            try
+            {
+                if (Options.Chart?.Id != null && isReady && blazor_apexchart is IJSInProcessObjectReference blazorApexChartInProcess)
+                {
+                    blazorApexChartInProcess.InvokeVoid("blazor_apexchart.destroyChart", Options.Chart.Id);
+                    blazorApexChartInProcess.Dispose();
+                }
+            }
+            catch (Exception ex) when (ex is ObjectDisposedException || ex is JSDisconnectedException)
+            { }
+            finally
+            {
+                DisposeManagedResources();
+                GC.SuppressFinalize(this);
+            }
         }
 
         /// <inheritdoc/>
         public virtual async ValueTask DisposeAsync()
         {
-            if (!DisposeCore())
+            if (!TryBeginDispose())
             {
                 return;
             }
@@ -1369,11 +1387,12 @@ namespace ApexCharts
             { }
             finally
             {
+                DisposeManagedResources();
                 GC.SuppressFinalize(this);
             }
         }
 
-        private bool DisposeCore()
+        private bool TryBeginDispose()
         {
             if (Interlocked.Exchange(ref isDisposed, 1) != 0)
             {
@@ -1381,8 +1400,15 @@ namespace ApexCharts
             }
 
             chartService?.UnRegisterChart(this);
-            JSHandler?.Dispose();
+            chartService = null;
             return true;
+        }
+
+        private void DisposeManagedResources()
+        {
+            JSHandler?.Dispose();
+            JSHandler = null;
+            blazor_apexchart = null;
         }
 
         internal void UpdateTooltipData(HoverData<TItem> tooltipData)

--- a/src/Blazor-ApexCharts/ApexChart.razor.cs
+++ b/src/Blazor-ApexCharts/ApexChart.razor.cs
@@ -33,7 +33,7 @@ namespace ApexCharts
     /// Main component to create an Apex chart in Blazor
     /// </summary>
     /// <typeparam name="TItem">The data type of the items to display in the chart</typeparam>
-    public partial class ApexChart<TItem> : IApexChartBase, IDisposable where TItem : class
+    public partial class ApexChart<TItem> : IApexChartBase, IDisposable, IAsyncDisposable where TItem : class
     {
         /// <summary>
         /// None generic version of the options object
@@ -387,6 +387,7 @@ namespace ApexCharts
         private JSHandler<TItem> JSHandler;
         private IJSObjectReference blazor_apexchart;
         private IApexChartService chartService;
+        private int isDisposed;
 
         /// <inheritdoc cref="Chart.Id"/>
         public string ChartId => chartId;
@@ -1341,22 +1342,38 @@ namespace ApexCharts
         /// <inheritdoc/>
         public virtual void Dispose()
         {
+            _ = DisposeAsync();
+        }
+
+        /// <inheritdoc/>
+        public virtual async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref isDisposed, 1) != 0)
+            {
+                return;
+            }
+
             GC.SuppressFinalize(this);
 
             chartService?.UnRegisterChart(this);
 
-            if (Options.Chart?.Id != null && isReady && blazor_apexchart != null)
+            try
             {
-                try
+                if (Options.Chart?.Id != null && isReady && blazor_apexchart != null)
                 {
-                    InvokeAsync(async () => { await InvokeVoidJsAsync("blazor_apexchart.destroyChart", Options.Chart.Id); });
-                    InvokeAsync(async () => { await blazor_apexchart.DisposeAsync(); });
+                    await InvokeAsync(async () =>
+                    {
+                        await InvokeVoidJsAsync("blazor_apexchart.destroyChart", Options.Chart.Id);
+                        await blazor_apexchart.DisposeAsync();
+                    });
                 }
-                catch (Exception ex) when (ex is ObjectDisposedException || ex is JSDisconnectedException)
-                { }
-
             }
-            JSHandler?.Dispose();
+            catch (Exception ex) when (ex is ObjectDisposedException || ex is JSDisconnectedException)
+            { }
+            finally
+            {
+                JSHandler?.Dispose();
+            }
         }
 
         internal void UpdateTooltipData(HoverData<TItem> tooltipData)


### PR DESCRIPTION
## Summary
- implement `IAsyncDisposable` on `ApexChart<TItem>`
- serialize chart teardown into a single awaited disposal path
- guard the disposal path against disconnected-circuit JS interop failures

## Why
This addresses #655, where `ApexChart.Dispose()` can trigger `JSDisconnectedException` on Blazor Server when the circuit is already disconnecting. The previous implementation queued async JS cleanup from `Dispose()` without awaiting it, which could leave the exception unobserved and surface later via `TaskScheduler.UnobservedTaskException`.