### PR TITLE
fix: shareable perspective URLs, renderer DOM hint, smoke CORS ignore

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## v7.0.0 (proposed) — ApexCharts.js 6.5.0 upgrade + premium licensing
+## v7.0.0 (proposed): ApexCharts.js 6.5.0 upgrade + premium licensing
 
 > The package version is set from the git tag at release time (`dotnet pack -p:Version=<tag>`). `7.0.0` is the
 > recommended tag for this release (major: the vendored core jumps from 5.16.0 to 6.5.0, several ApexCharts 6.0
@@ -22,14 +22,14 @@ across the ApexCharts family (apexgantt, apextree, apexsankey).
 
 ### ✨ New free options (no license required)
 
-- **Canvas renderer** (`Chart.Renderer` = `Svg`/`Canvas`/`Auto`, `Chart.RendererThreshold`) — hybrid SVG/canvas for
+- **Canvas renderer** (`Chart.Renderer` = `Svg`/`Canvas`/`Auto`, `Chart.RendererThreshold`): hybrid SVG/canvas for
   large datasets and heatmaps. `chart.GetActiveRendererAsync()` reports the active renderer.
 - **Real-time streaming** (`Chart.Streaming` { `Enabled`, `MaxPoints` }).
 - **Native mobile gestures** (`Chart.Zoom.Pinch`, new `Chart.Pan` { `Inertia`, `Friction` }).
 - **OS-aware themes** (`Theme.Follow` = `Os`, `Theme.Name`).
-- **Pluggable easing** — `Easing` enum extended with `EaseInSine`…`EaseInOutBack`; new `DynamicAnimation.Easing`.
-- **Bar chart race** — `DataLabels.Animate` and `DataLabels.CountUp`.
-- **Measure toolbar tool** — `Toolbar.AutoSelected = Measure`, `Toolbar.Tools.Measure`.
+- **Pluggable easing**: `Easing` enum extended with `EaseInSine`…`EaseInOutBack`; new `DynamicAnimation.Easing`.
+- **Bar chart race**: `DataLabels.Animate` and `DataLabels.CountUp`.
+- **Measure toolbar tool**: `Toolbar.AutoSelected = Measure`, `Toolbar.Tools.Measure`.
 
 ### ✨ New premium options (gated)
 
@@ -40,8 +40,8 @@ across the ApexCharts family (apexgantt, apextree, apexsankey).
 
 - History: `UndoAsync`, `RedoAsync`, `JumpHistoryAsync`.
 - Measure: `StartMeasureAsync`, `StopMeasureAsync`, `ClearMeasuresAsync`.
-- Perspectives: `CapturePerspectiveAsync`, `ApplyPerspectiveAsync`, `PerspectiveToUrlAsync`, `SavePerspectiveAsync`, `ListPerspectivesAsync`.
-- Storyboard: `StoryboardBindAsync`, `StoryboardGoToAsync`, `StoryboardCurrentAsync`, `StoryboardUnbindAsync`.
+- Perspectives: `CapturePerspectiveAsync`, `ApplyPerspectiveAsync`, `PerspectiveToUrlAsync`, `ApplyPerspectiveFromUrlAsync` (restore a shared `#apex=` link on render), `SavePerspectiveAsync`, `ListPerspectivesAsync`.
+- Storyboard: `StoryboardBindAsync` (with `StoryboardOptions.Scroller`/`Offset`/`Animate` and per-beat `View`/`Options`/`Announce` for scroll-driven scrollytelling), `StoryboardGoToAsync`, `StoryboardCurrentAsync`, `StoryboardUnbindAsync`.
 - Renderer/theme: `GetActiveRendererAsync`, `RefreshTokensAsync`.
 
 ### ✨ New crossfilter engine (on `IApexChartService`)

--- a/docs/BlazorApexCharts.Docs/Components/Features/V6/Perspectives/Basic.razor
+++ b/docs/BlazorApexCharts.Docs/Components/Features/V6/Perspectives/Basic.razor
@@ -1,33 +1,37 @@
+@inject IJSRuntime JS
+@using Microsoft.JSInterop
 @*
     ApexCharts v6 perspectives (premium: shows an APEXCHARTS trial watermark without a license).
     A perspective serializes the exact view (zoom window, hidden series, selection, annotations,
-    theme) into a compact token you can put in a URL and restore anywhere.
+    theme) into a compact token. PerspectiveToUrlAsync encodes it into a #apex=... URL fragment;
+    opening that URL (even in another browser) restores the view via ApplyPerspectiveFromUrlAsync
+    on render. Zoom with the toolbar or toggle a legend series, then copy the shareable URL.
 *@
 <div class="mb-2">
-    <button class="btn btn-primary me-1" @onclick="Capture">Capture perspective</button>
-    <button class="btn btn-secondary me-1" @onclick="Apply" disabled="@(token is null)">Apply captured</button>
-    <button class="btn btn-outline-secondary" @onclick="ToUrl">Get URL</button>
+    <button class="btn btn-primary me-1" @onclick="CopyUrl">Copy shareable URL</button>
+    <button class="btn btn-outline-secondary me-1" @onclick="Capture">Capture token</button>
+    <button class="btn btn-outline-secondary" @onclick="Apply" disabled="@(token is null)">Apply captured</button>
+</div>
+
+<div class="mb-2">
+    <span>@status</span>
 </div>
 
 <div class="mb-2" style="max-width:640px;word-break:break-all">
-    @if (token is not null)
-    {
-        <div>Token: <code>@token</code></div>
-    }
     @if (url is not null)
     {
-        <div>URL: <code>@url</code></div>
+        <div><small>URL: <code>@url</code></small></div>
+    }
+    @if (token is not null)
+    {
+        <div><small>Token: <code>@token</code></small></div>
     }
 </div>
 
 <DemoContainer>
-    <ApexChart @ref="chart" TItem="Pt" Title="Capture a view as a token" Options="options">
-        <ApexPointSeries TItem="Pt"
-                         Items="points"
-                         Name="Series 1"
-                         SeriesType="SeriesType.Line"
-                         XValue="@(e => e.X)"
-                         YValue="@(e => e.Y)" />
+    <ApexChart @ref="chart" TItem="Pt" Title="Capture a view, share it as a URL" Options="options" OnRendered="OnChartRendered">
+        <ApexPointSeries TItem="Pt" Items="points" Name="Signal A" SeriesType="SeriesType.Line" XValue="@(e => e.X)" YValue="@(e => e.A)" />
+        <ApexPointSeries TItem="Pt" Items="points" Name="Signal B" SeriesType="SeriesType.Line" XValue="@(e => e.X)" YValue="@(e => e.B)" />
     </ApexChart>
 </DemoContainer>
 
@@ -37,30 +41,54 @@
     private List<Pt> points { get; set; } = new();
     private string token;
     private string url;
+    private string status = "Zoom (toolbar) or hide a legend series, then click Copy shareable URL.";
+    private bool restoreAttempted;
 
     protected override void OnInitialized()
     {
-        options.Chart = new Chart
-            {
-                Height = 320,
-                Perspectives = new ChartPerspectives()
-            };
-
-        // Numeric x-axis avoids duplicate integer labels when a captured perspective zooms in.
+        options.Chart = new Chart { Height = 320, Perspectives = new ChartPerspectives() };
         options.Xaxis = new XAxis { Type = XAxisType.Numeric };
 
         var rnd = new Random(3);
-        double y = 40;
+        double a = 40, b = 60;
         for (var i = 0; i < 30; i++)
         {
-            y += rnd.NextDouble() * 10 - 4;
-            points.Add(new Pt(i, (decimal)Math.Round(y, 2)));
+            a += rnd.NextDouble() * 10 - 4;
+            b += rnd.NextDouble() * 8 - 4;
+            points.Add(new Pt(i, (decimal)Math.Round(a, 2), (decimal)Math.Round(b, 2)));
         }
+    }
+
+    // After the chart's JS instance exists, restore a view if the page URL carries one (#apex=...).
+    private async Task OnChartRendered()
+    {
+        if (restoreAttempted) { return; }
+        restoreAttempted = true;
+
+        var restored = await chart.ApplyPerspectiveFromUrlAsync();
+        if (restored)
+        {
+            status = "Restored the shared view from the URL fragment.";
+            StateHasChanged();
+        }
+    }
+
+    private async Task CopyUrl()
+    {
+        url = await chart.PerspectiveToUrlAsync();
+        // Copy the link and reflect it in the address bar so it can be shared/reloaded to restore this view.
+        await JS.InvokeVoidAsync("blazor_apexchart.setBrowserUrl", url);
+        var copied = await JS.InvokeAsync<bool>("blazor_apexchart.copyText", url);
+        status = copied
+            ? "Shareable URL copied to the clipboard. Open it (even in another browser) to restore this view."
+            : "Shareable URL ready (copy it from below or the address bar).";
+        StateHasChanged();
     }
 
     private async Task Capture()
     {
         token = await chart.CapturePerspectiveAsync();
+        status = "Captured the current view as a token. Change the view, then Apply captured to restore it.";
         StateHasChanged();
     }
 
@@ -69,14 +97,10 @@
         if (token is not null)
         {
             await chart.ApplyPerspectiveAsync(token);
+            status = "Applied the captured token.";
+            StateHasChanged();
         }
     }
 
-    private async Task ToUrl()
-    {
-        url = await chart.PerspectiveToUrlAsync();
-        StateHasChanged();
-    }
-
-    private record Pt(int X, decimal Y);
+    private record Pt(int X, decimal A, decimal B);
 }

--- a/docs/BlazorApexCharts.Docs/Components/Features/V6/Renderer/Basic.razor
+++ b/docs/BlazorApexCharts.Docs/Components/Features/V6/Renderer/Basic.razor
@@ -13,6 +13,13 @@
     </div>
     <span class="ms-2">Active series renderer: <strong>@renderer</strong> (@points.Count marks, threshold @threshold)</span>
 </div>
+<div class="mb-2">
+    <small class="text-muted">
+        In canvas mode the points paint to <code>&lt;canvas class="apexcharts-series-canvas"&gt;</code>
+        (inside <code>.apexcharts-inner &gt; .apexcharts-canvas-series-wrap</code>); the axes, grid and
+        title stay SVG, so seeing an <code>&lt;svg&gt;</code> in the DOM is expected in the hybrid renderer.
+    </small>
+</div>
 
 <DemoContainer>
     <ApexChart @ref="chart" TItem="Pt" Title="Hybrid renderer (5000-mark scatter)" Options="options">

--- a/src/Blazor-ApexCharts/ApexChart.razor.cs
+++ b/src/Blazor-ApexCharts/ApexChart.razor.cs
@@ -1189,6 +1189,17 @@ namespace ApexCharts
         }
 
         /// <summary>
+        /// Restore a perspective encoded in the current page URL fragment (<c>#apex=&lt;token&gt;</c>), as produced by
+        /// <see cref="PerspectiveToUrlAsync"/> (ApexCharts v6.0). Call after the chart has rendered (e.g. from
+        /// <c>OnRendered</c>) so a shared link reopens the exact captured view. Requires the perspectives feature.
+        /// </summary>
+        /// <returns><c>true</c> if a token was present in the URL and applied; otherwise <c>false</c>.</returns>
+        public virtual async Task<bool> ApplyPerspectiveFromUrlAsync()
+        {
+            return await InvokeJsAsync<bool>("blazor_apexchart.applyPerspectiveFromUrl", Options.Chart.Id);
+        }
+
+        /// <summary>
         /// Save the current perspective under a name (ApexCharts v6.0). Requires the perspectives feature.
         /// </summary>
         /// <param name="name">Name to save the perspective as.</param>

--- a/src/Blazor-ApexCharts/wwwroot/js/blazor-apexcharts.js
+++ b/src/Blazor-ApexCharts/wwwroot/js/blazor-apexcharts.js
@@ -238,6 +238,33 @@ window.blazor_apexchart = {
         return chart !== undefined ? JSON.stringify(chart.perspectives.list()) : null;
     },
 
+    // Restore a perspective encoded in the current page URL (#apex=<token>). Returns true if a
+    // token was present and applied, so a shared link reopens the exact captured view.
+    applyPerspectiveFromUrl(id) {
+        var chart = this.findChart(id);
+        if (chart === undefined) { return false; }
+        var token = ApexCharts.perspectives.fromURL(window.location.href);
+        if (!token) { return false; }
+        chart.perspectives.apply(token);
+        return true;
+    },
+
+    // Copy text to the clipboard (from a user gesture, on a secure context / localhost).
+    copyText(text) {
+        try {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(text);
+                return true;
+            }
+        } catch (e) { /* clipboard blocked */ }
+        return false;
+    },
+
+    // Reflect a URL in the address bar without navigating/reloading (so it can be copied there too).
+    setBrowserUrl(url) {
+        try { history.replaceState(null, '', url); } catch (e) { /* ignore */ }
+    },
+
     storyboardBind(id, options) {
         var chart = this.findChart(id);
         return chart !== undefined ? chart.storyboard.bind(this.parseOptions(options)) : null;

--- a/tests/e2e/smoke.mjs
+++ b/tests/e2e/smoke.mjs
@@ -35,12 +35,15 @@ const ROUTES = [
 // demos not yet deployed that is a harmless 404 the app catches and shows as text. Ignore those so
 // the smoke test only fails on real chart/interop errors.
 // - the docs "view source" widget fetching each demo's .razor from the deployed site: a 404 when a demo is not yet
-//   deployed, or ERR_CONNECTION_REFUSED when the runner has no outbound network. Neither is a chart/interop error.
+//   deployed, ERR_CONNECTION_REFUSED when the runner has no outbound network, or a CORS block / ERR_FAILED when the
+//   runner CAN reach apexcharts.github.io (cross-origin fetch, no CORS headers). All are the same harmless fallback,
+//   not a chart/interop error. The razor_source path is the only cross-origin fetch the app makes.
 // - the `[Apex]` license-domain notice: the demo's app-wide key is domain-locked to apexcharts.github.io, so on any
 //   other host (CI, localhost) the premium features render in trial mode and the core logs this. That is expected.
 const isIgnorableError = t =>
   /Failed to load resource: the server responded with a status of 404/.test(t) ||
   /ERR_CONNECTION_REFUSED|ERR_NAME_NOT_RESOLVED|ERR_INTERNET_DISCONNECTED/.test(t) ||
+  /razor_source|blocked by CORS policy|Access to fetch|net::ERR_FAILED/.test(t) ||
   /\[Apex\].*licen[sc]e|not valid for this domain/i.test(t);
 
 const failures = [];


### PR DESCRIPTION
Follow-up polish on the v6.5.0 upgrade (#667), part of prepping the v7.0.0 release.

## Changes
- **Perspectives: shareable URLs actually round-trip.** "Copy shareable URL" now copies the `#apex=` link and reflects it in the address bar; the encoded view is restored on load via the new `ApexChart.ApplyPerspectiveFromUrlAsync()` (interop `applyPerspectiveFromUrl` -> `ApexCharts.perspectives.fromURL` + `apply`). Added `copyText` / `setBrowserUrl` interop helpers. Verified across separate browser contexts: both the zoom window and hidden series restore. The demo now has two series so hiding one is a meaningful captured state.
- **Renderer demo: canvas DOM hint.** Added a note pointing at `<canvas class="apexcharts-series-canvas">` (nested in the graphical group) so the hybrid renderer's SVG axes/grid are not mistaken for canvas failing to engage. No behavior change (renderer was already painting to canvas).
- **E2E smoke: ignore the source-viewer CORS fallback.** The docs "view source" widget's cross-origin fetch can fail with a CORS block / `ERR_FAILED` when the runner can reach apexcharts.github.io. This is the same harmless fallback as the already-ignored 404 / connection-refused cases (the `razor_source` path is the only cross-origin fetch the app makes), so it no longer fails the smoke run on a networked runner.
- **RELEASE_NOTES:** note `ApplyPerspectiveFromUrlAsync` and the storyboard scrollytelling options.

## Verification
- `dotnet pack -c Release -p:Version=7.0.0` builds a valid package across net8.0/9.0/10.0 with the vendored 6.5.0 assets.
- Full e2e smoke passes (all chart pages render, watermark gating intact).