### PR TITLE
ci: fix GitHub release step (contents:write + modernize release.yml)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,14 @@
+name: Create Release
+
 on:
   push:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
-name: Create Release
+
+# The GitHub release step needs write access; the repo default token is read-only.
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Create Release
@@ -10,31 +16,30 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           8.0.x
           9.0.x
           10.0.x
 
-    - name: Dotnet Pack 
+    - name: Dotnet Pack
       working-directory: ./src/Blazor-ApexCharts
       run: dotnet pack -c Release -p:Version=${GITHUB_REF##*/v}
 
-    - name: Dotnet Nuget Push   
+    - name: Dotnet Nuget Push
       working-directory: ./src/Blazor-ApexCharts/bin/Release
       run: dotnet nuget push Blazor-ApexCharts.*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
       continue-on-error: false
 
-    - name: Create Release
-      uses: actions/create-release@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        tag_name: ${{ github.ref_name }}
+        name: ${{ github.ref_name }}
         draft: false
-        prerelease: true
+        prerelease: false
+        generate_release_notes: true


### PR DESCRIPTION
The `v7.0.0` release published to NuGet fine, but the workflow's final **Create Release** step failed with *"Resource not accessible by integration"*: the repo's default `GITHUB_TOKEN` is read-only, so `actions/create-release@master` could not create the GitHub release. (I created the v7.0.0 GitHub release manually with `gh` in the meantime.)

## Changes to `release.yml`
- Add `permissions: contents: write` so the release step can publish the GitHub release.
- Replace the deprecated/archived `actions/create-release@master` with the maintained `softprops/action-gh-release@v2` (`github.ref_name` for a clean release name, `generate_release_notes: true` for the body, `prerelease: false`).
- Bump `actions/checkout@v2` -> `@v4` and `actions/setup-dotnet@v3` -> `@v4` to clear the Node 20 deprecation warnings.

No change to the pack/NuGet-push steps. With this in place, the next `v*` tag will pack, publish to NuGet, and create the GitHub release automatically.

Note: `release-maui.yml` has no GitHub-release step (pack + NuGet push only), so it needs no permissions change.